### PR TITLE
Request Authorization to manage resources [Finishes ##11072…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "bcrypt"
 gem "active_model_serializers"
 gem "validates_email_format_of"
 gem "jwt"
+gem "cancancan"
 gem "simple_command"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
     bcrypt (3.1.10)
     builder (3.2.2)
     byebug (8.2.1)
+    cancancan (1.13.1)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
     concurrent-ruby (1.0.0)
@@ -147,6 +148,7 @@ DEPENDENCIES
   active_model_serializers
   bcrypt
   byebug
+  cancancan
   codeclimate-test-reporter
   database_cleaner
   factory_girl_rails
@@ -163,4 +165,4 @@ DEPENDENCIES
   validates_email_format_of
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/controllers/api/v1/bucketlists_controller.rb
+++ b/app/controllers/api/v1/bucketlists_controller.rb
@@ -20,20 +20,18 @@ module Api
       end
 
       def show
+        authorize_action :show
         render json: @bucketlist.to_json(include: :items)
       end
 
       def update
+        authorize_action :update
         return if params_arg_length_is_zero
-        if @bucketlist.update bucketlist_params
-          render json: { "message": "Bucketlist updated successfully" }
-        else
-          render json: { "message": @bucketlist.get_error },
-                 status: 400
-        end
+        update_helper
       end
 
       def destroy
+        authorize_action :destroy
         @bucketlist.destroy
         render json: { "message": "Bucketlist deleted successfully" }
       end
@@ -55,6 +53,19 @@ module Api
             render json: { "message": "Bucketlist empty" }, status: 204
           else
             render json: bucketlists.to_json(include: :items)
+          end
+        end
+
+        def authorize_action(action)
+          authorize! action, @bucketlist
+        end
+
+        def update_helper
+          if @bucketlist.update bucketlist_params
+            render json: { "message": "Bucketlist updated successfully" }
+          else
+            render json: { "message": @bucketlist.get_error },
+                   status: 400
           end
         end
 

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -14,15 +14,13 @@ module Api
       end
 
       def update
+        authorize_action :update
         return if params_arg_length_is_zero
-        if @item.update item_params
-          render json: { "message": "Item updated successfully" }
-        else
-          render json: { "message": @item.get_error }, status: 400
-        end
+        update_helper
       end
 
       def destroy
+        authorize_action :destroy
         @item.destroy
         render json: { "message": "Item deleted successfully" }
       end
@@ -33,10 +31,22 @@ module Api
           params.permit(:name, :done)
         end
 
+        def authorize_action(action)
+          authorize! action, @item
+        end
+
         def get_current_item
           @item = Item.find_by_id(params[:id])
           render json: { "message": "Invalid ID. Item not found." },
                  status: 404 if @item.nil?
+        end
+
+        def update_helper
+          if @item.update item_params
+            render json: { "message": "Item updated successfully" }
+          else
+            render json: { "message": @item.get_error }, status: 400
+          end
         end
 
         def params_arg_length_is_zero

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 class ApplicationController < ActionController::API
+  include CanCan::ControllerAdditions
+  attr_reader :current_user
+
   def authenticate_token
     request_auth = Api::RequestAuthorization.call(request.headers, params)
     if request_auth.success?
@@ -7,5 +10,10 @@ class ApplicationController < ActionController::API
       render json: { "errors": request_auth.errors },
              status: :unauthorized
     end
+  end
+
+  rescue_from CanCan::AccessDenied do
+    render json: { "message": "Unauthorized to access resource" },
+           status: :unauthorized
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,14 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    user ||= User.new
+
+    can :manage, Bucketlist, user_id: user.id
+    can :manage, Item do |item|
+      bucketlist = Bucketlist.find(item.bucketlist_id)
+
+      bucketlist.user_id == user.id
+    end
+  end
+end

--- a/spec/controllers/api/v1/bucketlists_controller_spec.rb
+++ b/spec/controllers/api/v1/bucketlists_controller_spec.rb
@@ -118,6 +118,15 @@ describe "BucketlistsController", type: :request do
         expect(response.status).to eql(404)
       end
 
+      it "returns an unauthorized status when trying "\
+        "to view a different user's bucketlist" do
+        token = token_helper
+        get "/bucketlists/#{unauthorized_random_id}", {},
+            HTTP_AUTHORIZATION: "token #{token}",
+            HTTP_ACCEPT: "application/vnd.apibucket.v1+json"
+        expect(response.status).to eql(401)
+      end
+
       it "returns a success status when trying to edit "\
       "a bucketlist with valid parameters" do
         token = token_helper

--- a/spec/controllers/api/v1/items_controller_spec.rb
+++ b/spec/controllers/api/v1/items_controller_spec.rb
@@ -110,6 +110,15 @@ describe "ItemsController", type: :request do
       expect(response.status).to eql(404)
     end
 
+    it "returns an unauthorized status when trying "\
+      "to edit an item in a different user's bucketlist" do
+      token = token_helper
+      put "/bucketlists/#{random_id}/items/#{unauthorized_random_id}", {},
+          HTTP_AUTHORIZATION: "token #{token}",
+          HTTP_ACCEPT: "application/vnd.apibucket.v1+json"
+      expect(response.status).to eql(401)
+    end
+
     it "returns a success status when trying to delete "\
       "an item" do
         token = token_helper

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,14 +1,22 @@
 module Api
   module Test
     shared_context "shared stuff" do
-      let(:random_id) { Bucketlist.order("RANDOM()").first.id }
-      let(:random_item_id) { Item.order("RANDOM()").first.id }
+      let(:random_id) do 
+        User.first.bucketlists.order("RANDOM()").first.id
+      end
+      let(:unauthorized_random_id) do
+        User.last.bucketlists.order("RANDOM()").first.id
+      end
+      let(:random_item_id) do
+        User.first.bucketlists.last.items.order("RANDOM()").first.id
+      end
       let(:valid_email) { "user1@seed.com" }
       let(:test_email) { "test@seed.com" }
       let(:invalid_test_email) { "test seed" }
       let(:test_pass) { "testpass" }
       let(:valid_pass) { "user1pass" }
       let(:invalid_id) { "u" }
+
       before(:all) do
         DatabaseCleaner.strategy = :truncation
       end


### PR DESCRIPTION
…6192]

Authorize requests that access the Database before serving responses.
Users should only be able to manage bucketlists created by them.
Items should also be restricted to the user that created the bucketlist under which it is saved.

Authorization was implemented using CanCanCan.
