### PR TITLE
Set root to redirect to Documentation [Finishes #111124904]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ APIBucket is an API service that allows users create bucketlists to store items.
 For full access to the API, a user account is required. After registration, an initial request is made to log in to user account. This request generates a JSON Web Token, which is returned in the response. This token is used to authenticate subsequent requests to the API. 
 
 For full documentation, and usage examples, see http://docs.apibucket.apiary.io/
+
 For API access, visit https://b-list.herokuapp.com
 
 ##API endpoints.

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,0 +1,5 @@
+class RootController < ApplicationController
+  def index
+    redirect_to "http://docs.apibucket.apiary.io/"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
               &routes_block
   end
 
+  root to: "root#index"
+
   namespace :api, path: "" do
     api_version_handler "1", true do
       resources :bucketlists, except: [:edit, :new] do


### PR DESCRIPTION
Set homepage to redirect to documentation page for API which is available at https://docs.apibucket.apiary.io
